### PR TITLE
Fix for issue on replacing match with exec

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const match = (payload, pattern, callback) => {
        * with the result object
        */
       if (value instanceof RegExp) {
-        const matcher = payload[key].match(value) || []
+        const matcher = value.exec(payload[key]) || []
         if (matcher.length > 0) {
           result.groups = { ...result.groups, ...matcher.groups }
           currentNode[key] = payload[key]
@@ -49,7 +49,7 @@ const match = (payload, pattern, callback) => {
            * Level N depth RegExp handling
            */
           if (element instanceof RegExp) {
-            const matcher = payload[key][index].match(element) || []
+            const matcher = element.exec(payload[key][index]) || []
             if (matcher.length > 0) {
               result.groups = { ...result.groups, ...matcher.groups }
               currentNode[key] = payload[key]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@menadevs/objectron",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/test_objectron.js
+++ b/test/test_objectron.js
@@ -389,6 +389,42 @@ suite('Objectron Core Tests', () => {
     assert.deepEqual(result, expected)
   })
 
+  test('Match number type values against regex pattern', () => {
+    const payload = {
+      age: 15,
+      shoeSize: 44.5,
+      temperature: {
+        type: 'celcius',
+        degree: -20
+      }
+    };
+
+    const result = match(payload, {
+      age: /\d*/,
+      shoeSize: /(\d+\.?\d*|\d*\.?\d+)/,
+      temperature: {
+        degree: /\-\d*/
+      }
+    });
+
+    const expected = {
+      match: true,
+      total: 3,
+      matches: {
+        age: 15,
+        shoeSize: 44.5,
+        temperature: {
+          degree: -20
+        }
+      },
+      groups: {}
+    }
+
+
+    assert.isTrue(result.match);
+    assert.deepEqual(result, expected);
+  });
+
   test('Callback fired on match', () => {
     let called = false
 
@@ -414,7 +450,8 @@ suite('Objectron Core Tests', () => {
         fields: [
           {
             type: 'plain_text',
-            text: 'going home?'
+            text: 'going home?',
+            rating: 5.5
           },
           {
             type: 'markdown',
@@ -432,7 +469,8 @@ suite('Objectron Core Tests', () => {
         fields: [
           {
             type: 'plain_text',
-            text: /(?<verb>\S+) (?<what>.+)?/
+            text: /(?<verb>\S+) (?<what>.+)?/,
+            rating: /(\d+\.?\d*|\d*\.?\d+)/
           }
         ]
       }
@@ -440,13 +478,19 @@ suite('Objectron Core Tests', () => {
 
     const expected = {
       match: true,
-      total: 7,
+      total: 8,
       matches: {
         api: 13,
         ids: [130, 45, 12],
         components: {
           type: 'section',
-          fields: [{ type: 'plain_text', text: 'going home?' }]
+          fields: [
+            { 
+              type: 'plain_text', 
+              text: 'going home?',
+              rating: 5.5
+            }
+          ]
         }
       },
       groups: { verb: 'going', what: 'home?' }


### PR DESCRIPTION
Switches to exec instead of match for regex pattern evaluation to support matching patterns for number values. [Issue](https://github.com/mena-devs/objectron/issues/10)