### PR TITLE
Documentation + test on using closures as wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,61 @@ console.dir(result, {depth: null});
 }
 ```
 
+### 7. Using closures as wildcard (Success)
+
+You can utilize closures to return an entire sub-object or sub-array from specific keys in a payload. This can be useful in cases where you want to return all values under a key without the need for further matching.
+
+```javascript
+const match = require('@menadevs/objectron');
+
+const payload = {
+  request: {
+    status: 200,
+    headers: [
+      {
+        "name": "User-Agent",
+        "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3)"
+      },
+      {
+        "name": "Referer",
+        "value": "https://www.somethingabcxyz.kfc/"
+      }
+    ]
+  }
+}
+
+const tester = {
+  request: {
+    status: 200,
+    headers: (val) => val
+  }
+};
+
+const result = match(payload, tester);
+
+# Output
+> {
+    match: true,
+    total: 2,
+    matches: {
+      request: {
+        status: 200,
+        headers: [
+          {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3)"
+          },
+          {
+            "name": "Referer",
+            "value": "https://www.somethingabcxyz.kfc/"
+          }
+        ]
+      }
+    },
+    groups: {}
+}
+```
+
 ## FAQs
 
 ### 1. What's the difference between Objectron and any other Schema Validator?

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@menadevs/objectron",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/test_objectron.js
+++ b/test/test_objectron.js
@@ -441,6 +441,55 @@ suite('Objectron Core Tests', () => {
     assert.isTrue(called)
   })
 
+  test('Callback used as wildcard', () => {
+    const payload = {
+      request: {
+        status: 200,
+        headers: [
+          {
+            "name": "User-Agent",
+            "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3)"
+          },
+          {
+            "name": "Referer",
+            "value": "https://www.somethingabcxyz.kfc/"
+          }
+        ]
+      }
+    }
+
+    const result = match(payload, {
+      request: {
+        status: 200,
+        headers: (val) => val
+      }
+    });
+
+    const expected = {
+      match: true,
+      total: 2,
+      matches: {
+        request: {
+          status: 200,
+          headers: [
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3)"
+            },
+            {
+              "name": "Referer",
+              "value": "https://www.somethingabcxyz.kfc/"
+            }
+          ]
+        }
+      },
+      groups: {}
+    }
+
+    assert.isTrue(result.match)
+    assert.deepEqual(result, expected)
+  })
+
   test('Variation of all the tests above', () => {
     const payload = {
       api: 13,


### PR DESCRIPTION
Adds an additional test and update on README to highlight the usage of closures for copying entire sub-values